### PR TITLE
Support python3.6 subprocess API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install CloudHummingbird
 
 It is recommended to use the ```--install-option="--prefix=$PREFIX_PATH"``` along with pip while installing Hummingbird. This would give users easy access to the sample configuration files located in conf/examples which the users might need to refer to while writing their own configuration file(s) for their own computational pipeline. Alternatively, the configuration files can be found here: ```<virtualenv_name>/lib/<python_ver>/site-packages/Hummingbird/conf/examples```
 
-Hummingbird requires pip and python 2.7 or python 3 as prerequesites for installation.
+Hummingbird requires pip and python 3 as prerequesites for installation.
 
 It is highly recommended to use a [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) to isolate the execution environment. Please follow the instructions from the above link to create a virtual environment, and then activate it:
 ```

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         ],
         package_dir={'': 'src'},
         packages=find_packages(where='src'),
-        python_requires='>=2.7, <4',
+        python_requires='>=3.6, <4',
         install_requires = _DEPENDENCIES,
         include_package_data=True,
         package_data={

--- a/src/Hummingbird/downsample.py
+++ b/src/Hummingbird/downsample.py
@@ -217,7 +217,7 @@ class Downsample(object):
                 target_path = '/'.join([bucket_dir, output_path, target_file])
                 ds_script.write(' '.join(['aws', 's3', 'cp', target_file, target_path]) + '\n') # Delocalization
                 downsampled[count_int][key] = target_path
-                output = subprocess.run(['aws', 's3', 'ls', target_path], check=False, capture_output=True)
+                output = subprocess.run(['aws', 's3', 'ls', target_path], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 if output.returncode != 0:  # if non-zero status code (i.e. file does not exist), then do not skip
                     skip = False
 


### PR DESCRIPTION
### Changes

Python 3.6 does not support `subprocess.run` kwarg of `check_output=`. As a result, use stdout and stderr.


### References

N/A

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

### Checklist

- [x] I have tested these changes
- [x] All existing and new tests complete without errors