### PR TITLE
Use DockerHub images. Fix AWS Batch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 RUN git clone https://github.com/lh3/seqtk.git && cd seqtk && make install
 
-ADD src/scripts/aws_fetch_and_run.sh /usr/local/bin/aws_fetch_and_run.sh
-ADD src/scripts/azure_fetch_and_run.sh /usr/local/bin/azure_fetch_and_run.sh
+COPY src/scripts/ /usr/local/bin/
 WORKDIR /tmp
+
+ENTRYPOINT ["/usr/local/bin/fetch_and_run.sh"]

--- a/Dockerfile-bwa
+++ b/Dockerfile-bwa
@@ -19,6 +19,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 RUN git clone https://github.com/lh3/seqtk.git && cd seqtk && make install
 
-ADD src/scripts/aws_fetch_and_run.sh /usr/local/bin/aws_fetch_and_run.sh
-ADD src/scripts/azure_fetch_and_run.sh /usr/local/bin/azure_fetch_and_run.sh
+COPY src/scripts/ /usr/local/bin/
 WORKDIR /tmp
+
+ENTRYPOINT ["/usr/local/bin/fetch_and_run.sh"]

--- a/src/Hummingbird/AWS/README.md
+++ b/src/Hummingbird/AWS/README.md
@@ -3,7 +3,7 @@
 For jobs specified using AWS, Hummingbird will launch jobs using AWS Batch. You will need to prepare for a customized docker image including the AWS CLI for your applications. This tutorial will include the instructions and preparation steps for your jobs.
 
 ## Use published Docker Image
-See [Hummingbird GitHub Packages](https://github.com/orgs/StanfordBioinformatics/packages?tab=packages&repo_name=Hummingbird) for latest Docker Images.
+See [Hummingbird GitHub Packages](https://hub.docker.com/u/cloudhummingbird) for latest Docker Images.
 
 If you need to use your private container registry or require custom packages, see below.
 

--- a/src/Hummingbird/AWS/compute_environment.json
+++ b/src/Hummingbird/AWS/compute_environment.json
@@ -11,15 +11,10 @@
         "instanceTypes": [
         ],
         "subnets": [
-            "subnet-6a370c13",
-            "subnet-6480a52f",
-            "subnet-acefe5f6",
-            "subnet-7f31b354"
         ],
         "securityGroupIds": [
-            "sg-57209e1d"
         ],
-        "ec2KeyPair": "hummingbird",
+        "ec2KeyPair": "",
         "instanceRole": "ecsInstanceRole",
         "tags": {
             "KeyName": "hummingbird"
@@ -29,5 +24,5 @@
             "version": "$Latest"
         }
     },
-    "serviceRole": "arn:aws:iam::834110226206:role/service-role/AWSBatchServiceRole"
+    "serviceRole": "<AWSServiceRoleForBatch>"
 }

--- a/src/Hummingbird/AWS/job-definition.json
+++ b/src/Hummingbird/AWS/job-definition.json
@@ -2,7 +2,7 @@
     "jobDefinitionName": "hummingbird-job",
     "type": "container",
     "containerProperties": {
-        "image": "docker.pkg.github.com/stanfordbioinformatics/hummingbird/bwa:1.0",
+        "image": "cloudhummingbird/bwa:1.0",
         "vcpus": 0,
         "memory": 0,
         "command": [
@@ -10,7 +10,7 @@
             "-c",
             "/usr/local/bin/aws_fetch_and_run.sh"
         ],
-        "jobRoleArn": "arn:aws:iam::834110226206:role/ecsTaskExecutionRole",
+        "jobRoleArn": "<ecsTaskExecutionRole>",
         "volumes": [
         ],
         "environment": [

--- a/src/Hummingbird/Azure/README.md
+++ b/src/Hummingbird/Azure/README.md
@@ -14,7 +14,7 @@ For jobs specified using Azure, Hummingbird will launch jobs using Azure Batch.
 You will need to prepare for a customized Docker Image including the Azure CLI for your applications. This tutorial will include the instructions and preparation steps for your jobs.
 
 ## Use published Docker Image
-See [Hummingbird GitHub Packages](https://github.com/orgs/StanfordBioinformatics/packages?tab=packages&repo_name=Hummingbird) for latest Docker Images.
+See [Hummingbird GitHub Packages](https://hub.docker.com/u/cloudhummingbird) for latest Docker Images.
 
 If you need to use your private container registry or require custom packages, see below.
 

--- a/src/Hummingbird/Azure/task.json
+++ b/src/Hummingbird/Azure/task.json
@@ -1,6 +1,6 @@
 [
   {
-    "image": "docker.pkg.github.com/stanfordbioinformatics/hummingbird/bwa:1.0",
+    "image": "cloudhummingbird/bwa:1.0",
     "commandLine": "/bin/bash -c '/usr/local/bin/azure_fetch_and_run.sh'",
     "constraints": {
       "maxWallClockTime": "P4D",

--- a/src/Hummingbird/conf/examples/bwa.azure.conf.json
+++ b/src/Hummingbird/conf/examples/bwa.azure.conf.json
@@ -22,7 +22,7 @@
   },
   "Profiling": [
     {
-      "image": "docker.pkg.github.com/stanfordbioinformatics/hummingbird/bwa:1.0",
+      "image": "cloudhummingbird/bwa:1.0",
       "result": "result/bwa",
       "thread": [8, 16, 32],
       "input-recursive": {

--- a/src/Hummingbird/conf/examples/bwa.conf.json
+++ b/src/Hummingbird/conf/examples/bwa.conf.json
@@ -18,7 +18,7 @@
   },
   "Profiling": [
     {
-      "image": "docker.pkg.github.com/stanfordbioinformatics/hummingbird/bwa:1.0",
+      "image": "cloudhummingbird/bwa:1.0",
       "logging": "logging/bwa",
       "result": "result/bwa",
       "thread": [8, 16, 32],

--- a/src/scripts/fetch_and_run.sh
+++ b/src/scripts/fetch_and_run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ -n "$AWS_BATCH_JOB_ID" ]]; then
+  source aws_fetch_and_run.sh "${@}"
+  exit 0
+fi
+
+if [[ -n "$AZ_BATCH_ACCOUNT_NAME" ]]; then
+  source azure_fetch_and_run.sh "${@}"
+  exit 0
+fi
+
+echo "Invalid cloud provider (missing 'AZ_BATCH_ACCOUNT_NAME' and 'AWS_BATCH_JOB_ID' env vars." >&2
+exit 1


### PR DESCRIPTION
Use DockerHub images. Fix AWS Batch to allow to use latest launch template and job definition