### PR TITLE
Extend job waiter to 2 days as long runs (e.g. full-run) can take up to 2 days

### DIFF
--- a/Hummingbird/scheduler.py
+++ b/Hummingbird/scheduler.py
@@ -242,7 +242,7 @@ class AWSBatchScheduler(BaseBatchSchduler):
                 waiter_id: {
                     'delay': 60,
                     'operation': 'DescribeJobs',
-                    'maxAttempts': 24 * 60,
+                    'maxAttempts': 24 * 60 * 2,  # timeout of 2 days
                     'acceptors': [
                         {
                             'expected': 'SUCCEEDED',

--- a/Hummingbird/test/test_scheduler.py
+++ b/Hummingbird/test/test_scheduler.py
@@ -54,5 +54,5 @@ class TestAWSScheduler(unittest.TestCase):
         compute_env_waiter = self.instance.get_compute_job_waiter(waiter_id)
 
         self.assertEqual(waiter_id, compute_env_waiter.name)
-        self.assertEqual(24 * 60, compute_env_waiter.config.max_attempts)
+        self.assertEqual(24 * 60 * 2, compute_env_waiter.config.max_attempts)
         self.assertEqual(60, compute_env_waiter.config.delay)


### PR DESCRIPTION
### Changes

Extend job waiter to 2 days as long runs (e.g. full-run) can take up to 2 days


### References

Issue reported: 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

### Checklist

- [x] I have tested these changes
- [x] All existing and new tests complete without errors