### PR TITLE
fix: use xvda for AL2; use unique launch template depending on disk size

### DIFF
--- a/Hummingbird/AWS/launch-template-data.json
+++ b/Hummingbird/AWS/launch-template-data.json
@@ -8,25 +8,7 @@
         "Ebs": {
           "DeleteOnTermination": true,
           "VolumeType": "gp3",
-          "VolumeSize": 50
-        }
-      },
-      {
-        "DeviceName": "/dev/xvdcz",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "VolumeType": "gp3",
-          "VolumeSize": 22,
-          "Encrypted": true
-        }
-      },
-      {
-        "DeviceName": "/dev/xvdba",
-        "Ebs": {
-          "DeleteOnTermination": true,
-          "VolumeType": "gp3",
-          "VolumeSize": 100,
-          "Encrypted": true
+          "VolumeSize": 100
         }
       }
     ]

--- a/Hummingbird/conf/examples/bwa.aws.conf.json
+++ b/Hummingbird/conf/examples/bwa.aws.conf.json
@@ -12,15 +12,24 @@
       "INPUT_R2": "s3://bwa-hummingbird/fastq/ERR194159_2.fastq.gz"
     },
     "target": 707646124,
-    "fractions": [0.001, 0.01, 0.1],
+    "fractions": [
+      0.001,
+      0.01,
+      0.1
+    ],
     "output": "downsampled",
+    "disk": "200",
     "fullrun": false
   },
   "Profiling": [
     {
       "image": "docker.pkg.github.com/stanfordbioinformatics/hummingbird/bwa:1.0",
       "result": "result/bwa",
-      "thread": [8, 16, 32],
+      "thread": [
+        8,
+        16,
+        32
+      ],
       "input-recursive": {
         "REF": "references/GRCh37lite"
       },

--- a/Hummingbird/test/test_scheduler.py
+++ b/Hummingbird/test/test_scheduler.py
@@ -7,6 +7,7 @@ from mock import patch, MagicMock, mock_open
 from Hummingbird.errors import SchedulerException
 from Hummingbird.hummingbird_utils import PLATFORM
 from Hummingbird.scheduler import AWSBatchScheduler
+from Hummingbird.instance import AWSInstance
 from Hummingbird.hummingbird_utils import get_full_path
 
 
@@ -23,7 +24,7 @@ class TestAWSScheduler(unittest.TestCase):
     ]
 
     def setUp(self):
-        self.instance = AWSBatchScheduler(self.conf, None, 100, None)
+        self.instance = AWSBatchScheduler(self.conf, AWSInstance(), 100, None)
 
     def test_instance_fields(self):
         instance = AWSBatchScheduler(self.conf, None, None, None)
@@ -97,6 +98,7 @@ class TestAWSScheduler(unittest.TestCase):
 
         with open(get_full_path('AWS/launch-template-data.json')) as tpl:
             data = json.load(tpl)
+            data['LaunchTemplateName'] = self.instance.get_compute_name()
             client_mock.create_launch_template_version.assert_called_once_with(**data)
 
     @patch('boto3.client', return_value=MagicMock())


### PR DESCRIPTION
### Changes

1. Per [AWS Doc](https://aws.amazon.com/premiumsupport/knowledge-center/batch-job-failure-disk-space/),  AL2 on ECS should only use `/dev/xvda` for docker volume
2. Use unique names for launch template in case of concurrent job execution

### Checklist

- [x] I have tested these changes
- [x] All existing and new tests complete without errors